### PR TITLE
test: cifull label triggers all jobs on PR

### DIFF
--- a/cifull.txt
+++ b/cifull.txt
@@ -1,0 +1,1 @@
+ci-full test file


### PR DESCRIPTION
Testing that applying the ci-full label causes heavy jobs to run even on a PR.